### PR TITLE
Add some (commented) properties for end-users reference

### DIFF
--- a/GreetingsBots/GreetingsBot/GreetingsBot.properties
+++ b/GreetingsBots/GreetingsBot/GreetingsBot.properties
@@ -7,3 +7,8 @@ xatkit.libraries.custom.GreetingsBotLib = src/GreetingsBot.intent
 # Set a concrete platform to use in place of the ChatPlatform
 xatkit.platforms.abstract.ChatPlatform = com.xatkit.plugins.react.platform.ReactPlatform
 
+# Set the server port to use (defaults to 5000)
+# xatkit.server.port = 5000
+
+# Xatkit server location, i.e. public URL (defaults to "http://localhost")
+# xatkit.server.public_url = http://localhost


### PR DESCRIPTION
By default, the examples run in localhost. However, when deploying the bot in another machine it is necessary to set some properties that are not obvious to find. I think it's a good idea to have them in the example bot provided to give a quick reference.